### PR TITLE
Fix hidden Listing rows in relationship panels

### DIFF
--- a/client/modules/pim/src/views/listing/fields/classification.js
+++ b/client/modules/pim/src/views/listing/fields/classification.js
@@ -36,6 +36,13 @@ Espo.define('pim:views/listing/fields/classification', 'views/fields/link',
         afterRender() {
             Dep.prototype.afterRender.call(this);
 
+            // In a list view, $el.parent() is the complete table row. The
+            // channel may not be part of the selected list attributes, so
+            // hiding the parent would incorrectly hide the whole record.
+            if (this.isListView()) {
+                return;
+            }
+
             if (this.model.get('channelId')) {
                 this.$el.parent().show();
             } else {


### PR DESCRIPTION
## Summary

Prevent the Listing classification field from hiding an entire table row when it is rendered inside a relationship list.

## Reproduction

1. Create a Channel with Listings that have classifications.
2. Configure the Channel's Listings relationship panel without the Channel column.
3. Open the Channel detail view.
4. The relationship count and pagination show the Listings, but all rows are visually hidden.

## Root cause

The custom classification field calls `this.$el.parent().hide()` when `channelId` is not present. In a list view, the parent element is the complete table row. Relationship list queries do not necessarily select `channelId`, so valid records are hidden even though the API returns them.

## Fix

Skip the detail/edit-specific parent visibility logic in list views. The existing behavior remains unchanged outside list views.

## Validation

- Exercised list view rendering with no selected `channelId`: neither `show()` nor `hide()` is called on the row.
- Exercised detail rendering with and without `channelId`: the existing show/hide behavior is preserved.
- `node --check client/modules/pim/src/views/listing/fields/classification.js`
- `git diff --check`

Fixes #743.
